### PR TITLE
Updated one-line change missed in last merge

### DIFF
--- a/bios.asm
+++ b/bios.asm
@@ -3002,7 +3002,11 @@ numbers:   db      027h,010h,3,0e8h,0,100,0,10,0,1
 
            org     BASE+0f00h
 f_boot:    lbr     bootide
-f_type:    lbr     tty
+#ifdef UART
+f_type:    lbr     e2k_tx
+#else
+f_type:    lbr     type
+#endif
 #ifdef UART
 f_read:    lbr     e2k_rx
 #else

--- a/bios.asm
+++ b/bios.asm
@@ -3002,7 +3002,7 @@ numbers:   db      027h,010h,3,0e8h,0,100,0,10,0,1
 
            org     BASE+0f00h
 f_boot:    lbr     bootide
-f_type:    lbr     type
+f_type:    lbr     tty
 #ifdef UART
 f_read:    lbr     e2k_rx
 #else


### PR DESCRIPTION
Changed definition of f_type: to match the definition in Bob Armstrong's original updated bios.asm file.  This change was missed in the earlier compare and merge.