### PR TITLE
Merged changes for MChip and STG ROM builds

### DIFF
--- a/bios.asm
+++ b/bios.asm
@@ -132,7 +132,7 @@ uart_test: sex     r3               ; [RLA] output immediate data
            sex     r2               ; [RLA] point to the stack again
            inp     UART_DATA        ; [RLA] read the MSR
            ani     0f0h             ; [RLA] check the current modem status
-           lbnz    no_uart          ; [RLA] all bits should be zero
+           bnz    no_uart           ; [RLA] all bits should be zero
            sex     r3               ; [RLA] back to X=P
            out     UART_SELECT      ; [RLA] select the MCR again
            db      14h              ; [RLA] ...
@@ -144,7 +144,7 @@ uart_test: sex     r3               ; [RLA] output immediate data
            inp     UART_DATA        ; [RLA] read the MSR
            ani     0f0h             ; [RLA] check the current modem status
            xri     0f0h             ; [RLA] all bits should be one this time
-           lbnz    no_uart          ; [RLA] no uart if they arent
+           bnz    no_uart           ; [RLA] no uart if they arent
            sex     r3               ; [RLA] X=P
            out     UART_SELECT      ; [RLA] select the MCR once more
            db      14h              ; [RLA] ...
@@ -208,7 +208,7 @@ abdlp1: ldn        rf                ; [RLA] get a byte from auto baud table
         xor                          ; [RLA] compare it to byte on the stack
         lbz        abd2              ; [RLA] branch if we found a match
         inc        rf                ; [RLA] skip the second byte
-        lbr        abdlp1            ; [RLA] and keep looking
+        br         abdlp1            ; [RLA] and keep looking
 
 ;   Here if we find a match in the auto baud table.  Remember that were
 ; receiving at a fairly fast rate (9600bps) and if the operator was sending
@@ -619,7 +619,7 @@ nortc:  irx                     ; [RLA] pop two bytes off the stack
 ; ********************************
 e2k_gtod:   sep     scall               ; see if RTC is present
             dw      rtctest
-            lbdf    rtc_go              ; jump if RTC was found
+            bdf     rtc_go              ; jump if RTC was found
 ; Here if there is no RTC installed...
 rtc_err:    smi     0                   ; signal error
             ldi     0                   ; as no RTC
@@ -641,13 +641,13 @@ rtc_go: sep     scall           ; [RLA] first read register 0x0a
         db      80h+0ah         ; [RLA] ...
         ani     70h             ; [RLA] check the DV2/1/0 bits
         xri     20h             ; [RLA] make sure the clock is running
-        lbnz    rtc_notset      ; [RLA] not runing otherwise
+        bnz     rtc_notset      ; [RLA] not runing otherwise
         sep     scall           ; [RLA] now read register 0x0b
         dw      rtcrdi          ; [RLA] ...
         db      80h+0bh         ; [RLA] ...
         ani     06h             ; [RLA] make sure the DM and 24 bits are set
         xri     06h             ; [RLA] (both bits must be set!)
-        lbnz    rtc_notset      ; [RLA] clock is not set otherwise
+        bnz     rtc_notset      ; [RLA] clock is not set otherwise
 
 ;   The second caveat is that we have to be careful _when_ we read the clock.
 ; Remember, the RTC hardware potentially changes the seconds, minutes, hours
@@ -665,7 +665,7 @@ rtc_w1: sep     scall           ; [RLA] UIP is in register 0x0a
         dw      rtcrdi          ; [RLA] ...
         db      80h+0ah         ; [RLA] ...
         ani     80h             ; [RLA] wait for UIP to be clear
-        lbnz    rtc_w1          ; [RLA] ...
+        bnz     rtc_w1          ; [RLA] ...
 
 ; Ok, were safe...  Read the clock...
         sep     scall           ; [RLA] first the month
@@ -1331,7 +1331,7 @@ sz_ready:  sex     r3                  ; issued commands to perform an ident
 size_lp1:  inp     IDE_DATA            ; read byte from drive
            dec     rc                  ; decrement count
            glo     rc                  ; see if done
-           lbnz    size_lp1            ; loop back if not
+           bnz     size_lp1            ; loop back if not
            inp     IDE_DATA            ; read 4 bytes into r8:r7
            plo     r7
            plo     rf                  ; also into RF
@@ -1405,7 +1405,7 @@ btchk_lp:
            plo     rd                  ; save value
            dec     rc                  ; decrement byte count
            glo     rc                  ; see if done
-           lbnz    btchk_lp            ; loop back if not
+           bnz     btchk_lp            ; loop back if not
            sex     r2                  ; point X back to stack
            glo     rd                  ; get number
            smi     060h                ; check against check value

--- a/bios.asm
+++ b/bios.asm
@@ -3129,5 +3129,5 @@ inpterm:   smi     0                   ; signal <CTRL><C> exit
          lbr     ret
 
          org     BASE+0ff9h
-version: db      1,0,12
+version: db      1,0,13
 chsum:   db      0,0,0,0

--- a/bios.asm
+++ b/bios.asm
@@ -1,4 +1,9 @@
-#include    ../include/ops.inc
+.op "PUSH","N","8$1 73 9$1 73"
+.op "POP","N","60 72 B$1 F0 A$1"
+.op "CALL","W","D4 H1 L1"
+.op "RTN","","D5"
+.op "MOV","NR","8$2 A$1 9$2 B$1"
+.op "MOV","NW","F8 L2 A$1 F8 H2 B$1"
 
 ; *******************************************************************
 ; *** This software is copyright 2005 by Michael H Riley          ***
@@ -132,7 +137,7 @@ uart_test: sex     r3               ; [RLA] output immediate data
            sex     r2               ; [RLA] point to the stack again
            inp     UART_DATA        ; [RLA] read the MSR
            ani     0f0h             ; [RLA] check the current modem status
-           bnz    no_uart           ; [RLA] all bits should be zero
+           bnz     no_uart          ; [RLA] all bits should be zero
            sex     r3               ; [RLA] back to X=P
            out     UART_SELECT      ; [RLA] select the MCR again
            db      14h              ; [RLA] ...
@@ -1690,13 +1695,14 @@ mainlp:    ldi     high prompt         ; get address of prompt
            ghi     rc                  ; retrieve command
            smi     33
            bz      storesp
+
 #ifdef ANYROM
-           smi     14                  ; check for / return to os
-           lbz     EXIT_ADDR           ; ROM exit vector        
-           smi     14                  ; look for copy command
-#else            
+          smi     14                  ; check for / return to os
+          lbz     EXIT_ADDR           ; ROM exit vector        
+          smi     14                  ; look for copy command
+#else                       
            smi     28                  ; look for copy command
-#endif
+#endif           
            bz      copy                ; jump if found
            smi     2
            bz      examine
@@ -3129,5 +3135,5 @@ inpterm:   smi     0                   ; signal <CTRL><C> exit
          lbr     ret
 
          org     BASE+0ff9h
-version: db      1,0,13
+version: db      1,0,12
 chsum:   db      0,0,0,0

--- a/bios.asm
+++ b/bios.asm
@@ -1,9 +1,4 @@
-.op "PUSH","N","8$1 73 9$1 73"
-.op "POP","N","60 72 B$1 F0 A$1"
-.op "CALL","W","D4 H1 L1"
-.op "RTN","","D5"
-.op "MOV","NR","8$2 A$1 9$2 B$1"
-.op "MOV","NW","F8 L2 A$1 F8 H2 B$1"
+#include    ../include/ops.inc
 
 ; *******************************************************************
 ; *** This software is copyright 2005 by Michael H Riley          ***
@@ -29,6 +24,8 @@
 #define SERSEQ          req     ;  ...
 #define SERREQ          seq     ;  ...
 #define BASE            0f000h
+#define ANYROM
+#define EXIT_ADDR       08003h
 #endif
 
 ; [RLA] Spare Time Gizmos Elf 2000 configuration ...
@@ -53,6 +50,8 @@ include config.inc
 #define BKBD            b2      ; branch on keyboard data ready
 #define BNKBD           bn2     ;  ... no keyboard data ready
 #define BASE            0f000h
+#define ANYROM
+#define EXIT_ADDR       08003h
 #endif
 
 #ifdef MC
@@ -73,6 +72,8 @@ include config.inc
 #define  IDE_SELECT   2       ;  ... IDE register select I/O port
 #define  IDE_DATA     3       ;  ... IDE data I/O port
 #define BASE          00000h
+#define ANYROM
+#define EXIT_ADDR     07003h
 #endif
 
 #ifndef SERP
@@ -1689,7 +1690,13 @@ mainlp:    ldi     high prompt         ; get address of prompt
            ghi     rc                  ; retrieve command
            smi     33
            bz      storesp
+#ifdef ANYROM
+           smi     14                  ; check for / return to os
+           lbz     EXIT_ADDR           ; ROM exit vector        
+           smi     14                  ; look for copy command
+#else            
            smi     28                  ; look for copy command
+#endif
            bz      copy                ; jump if found
            smi     2
            bz      examine
@@ -2982,7 +2989,7 @@ getdev:    ldi     DEVICES+UARTDEV+NVRDEV  ; load map of supported devices
            ldi     0                   ; high byte is zero
            phi     rf                  ; ...
            sep     sret                ; return
-#endif
+; #endif
 
 numbers:   db      027h,010h,3,0e8h,0,100,0,10,0,1
 

--- a/bios.inc
+++ b/bios.inc
@@ -10,6 +10,12 @@
 #define equ .equ
 #endif
 
+; Define BIOS vectors for MCHIP ROM
+#ifdef MCHIP
+#define BIOS  00f00h
+#define EBIOS 00800h
+#endif
+
 ; Define address for standard BIOS vectors
 #ifndef BIOS
 #define BIOS 0ff00h
@@ -21,62 +27,65 @@
 #endif
 
 #ifndef _TASM_
-scall:      equ  r4                    ; register for SCALL
-sret:       equ  r5                    ; register for SRET
-
-call:       equ  0ffe0h                ; depricated
-ret:        equ  0fff1h                ; depricated
+scall:      equ  r4                 ; register for SCALL
+sret:       equ  r5                 ; register for SRET
+#ifdef MCHIP
+call:       equ  00fe0h             ; deprecated
+ret:        equ  00ff1h             ; deprecated
+#else 
+call:       equ  0ffe0h             ; deprecated
+ret:        equ  0fff1h             ; deprecated
 #endif
+#endif                                  
 
-f_boot:     equ  (BIOS+00h)            ; boot from ide device
-f_type:     equ  (BIOS+03h)            ; type 1 character to console
-f_read:     equ  (BIOS+06h)            ; read 1 character from console
-f_msg:      equ  (BIOS+09h)            ; type asciiz string to console
-f_typex:    equ  (BIOS+0ch)            ; depricated, just returns now
-f_input:    equ  (BIOS+0fh)            ; read asciiz from console
-f_strcmp:   equ  (BIOS+12h)            ; compare 2 strings
-f_ltrim:    equ  (BIOS+15h)            ; trim leading spaces
-f_strcpy:   equ  (BIOS+18h)            ; copy an asciiz string
-f_memcpy:   equ  (BIOS+1bh)            ; copy memory
-f_wrtsec:   equ  (BIOS+1eh)            ; write floppy sector (depricated)
-f_rdsec:    equ  (BIOS+21h)            ; read floppy sector (depricated)
-f_seek0:    equ  (BIOS+24h)            ; floppy seek to track 0 (depricated)
-f_seek:     equ  (BIOS+27h)            ; floopy track seek (depricated)
-f_drive:    equ  (BIOS+2ah)            ; select floppy drive (depricated)
-f_setbd:    equ  (BIOS+2dh)            ; set console baud rate
-f_mul16:    equ  (BIOS+30h)            ; 16-bit multiply
-f_div16:    equ  (BIOS+33h)            ; 16-bit division
-f_idereset: equ  (BIOS+36h)            ; reset ide device
-f_idewrite: equ  (BIOS+39h)            ; write ide sector
-f_ideread:  equ  (BIOS+3ch)            ; read ide sector
-f_initcall: equ  (BIOS+3fh)            ; initialize R4 and R5
-f_bootide:  equ  (BIOS+42h)            ; boot from ide device
-f_hexin:    equ  (BIOS+45h)            ; convert ascii number to hex
-f_hexout2:  equ  (BIOS+48h)            ; convert hex to 2-digit ascii
-f_hexout4:  equ  (BIOS+4bh)            ; convert hex to 4-digit ascii
-f_tty:      equ  (BIOS+4eh)            ; type character to console
-f_mover:    equ  (BIOS+51h)            ; program relocator
-f_minimon:  equ  (BIOS+54h)            ; mini monitor
-f_freemem:  equ  (BIOS+57h)            ; determine memory size
-F_isnum:    equ  (BIOS+5ah)            ; determine if D is numeric
-f_atoi:     equ  (BIOS+5dh)            ; convert ascii to integer
-f_uintout:  equ  (BIOS+60h)            ; convert unsigned integer to ascii
-f_intout:   equ  (BIOS+63h)            ; convert signed integer to ascii
-f_inmsg:    equ  (BIOS+66h)            ; type in-line message
-f_inputl:   equ  (BIOS+69h)            ; read limited line from console
-f_brktest:  equ  (BIOS+6ch)            ; check for serial break
-f_findtkn:  equ  (BIOS+6fh)            ; find token in a token table
-f_isalpha:  equ  (BIOS+72h)            ; determine if D is alphabetic
-f_ishex:    equ  (BIOS+75h)            ; determine if D is hexadecimal
-f_isalnum:  equ  (BIOS+78h)            ; determine if D is alpha or numeric
-f_idnum:    equ  (BIOS+7bh)            ; determine type of ascii number
-f_isterm:   equ  (BIOS+7eh)            ; determine if D is a termination char
-f_getdev:   equ  (BIOS+81h)            ; get supported devices
+f_boot:     equ  (BIOS+00h)         ; boot from ide device
+f_type:     equ  (BIOS+03h)         ; type 1 character to console
+f_read:     equ  (BIOS+06h)         ; read 1 character from console
+f_msg:      equ  (BIOS+09h)         ; type asciiz string to console
+f_typex:    equ  (BIOS+0ch)         ; deprecated, just returns now
+f_input:    equ  (BIOS+0fh)         ; read asciiz from console
+f_strcmp:   equ  (BIOS+12h)         ; compare 2 strings
+f_ltrim:    equ  (BIOS+15h)         ; trim leading spaces
+f_strcpy:   equ  (BIOS+18h)         ; copy an asciiz string
+f_memcpy:   equ  (BIOS+1bh)         ; copy memory
+f_wrtsec:   equ  (BIOS+1eh)         ; write floppy sector (depricated)
+f_rdsec:    equ  (BIOS+21h)         ; read floppy sector (depricated)
+f_seek0:    equ  (BIOS+24h)         ; floppy seek to track 0 (depricated)
+f_seek:     equ  (BIOS+27h)         ; floopy track seek (depricated)
+f_drive:    equ  (BIOS+2ah)         ; select floppy drive (depricated)
+f_setbd:    equ  (BIOS+2dh)         ; set console baud rate
+f_mul16:    equ  (BIOS+30h)         ; 16-bit multiply
+f_div16:    equ  (BIOS+33h)         ; 16-bit division
+f_idereset: equ  (BIOS+36h)         ; reset ide device
+f_idewrite: equ  (BIOS+39h)         ; write ide sector
+f_ideread:  equ  (BIOS+3ch)         ; read ide sector
+f_initcall: equ  (BIOS+3fh)         ; initialize R4 and R5
+f_bootide:  equ  (BIOS+42h)         ; boot from ide device
+f_hexin:    equ  (BIOS+45h)         ; convert ascii number to hex
+f_hexout2:  equ  (BIOS+48h)         ; convert hex to 2-digit ascii
+f_hexout4:  equ  (BIOS+4bh)         ; convert hex to 4-digit ascii
+f_tty:      equ  (BIOS+4eh)         ; type character to console
+f_mover:    equ  (BIOS+51h)         ; program relocator
+f_minimon:  equ  (BIOS+54h)         ; mini monitor
+f_freemem:  equ  (BIOS+57h)         ; determine memory size
+f_isnum:    equ  (BIOS+5ah)         ; determine if D is numeric
+f_atoi:     equ  (BIOS+5dh)         ; convert ascii to integer
+f_uintout:  equ  (BIOS+60h)         ; convert unsigned integer to ascii
+f_intout:   equ  (BIOS+63h)         ; convert signed integer to ascii
+f_inmsg:    equ  (BIOS+66h)         ; type in-line message
+f_inputl:   equ  (BIOS+69h)         ; read limited line from console
+f_brktest:  equ  (BIOS+6ch)         ; check for serial break
+f_findtkn:  equ  (BIOS+6fh)         ; find token in a token table
+f_isalpha:  equ  (BIOS+72h)         ; determine if D is alphabetic
+f_ishex:    equ  (BIOS+75h)         ; determine if D is hexadecimal
+f_isalnum:  equ  (BIOS+78h)         ; determine if D is alpha or numeric
+f_idnum:    equ  (BIOS+7bh)         ; determine type of ascii number
+f_isterm:   equ  (BIOS+7eh)         ; determine if D is a termination char
+f_getdev:   equ  (BIOS+81h)         ; get supported devices
 
-f_version:  equ  (BIOS+0f9h)           ; 3 bytes holding bios version number
+f_version:  equ  (BIOS+0f9h)        ; 3 bytes holding bios version number
 
 ; "Extended" BIOS vectors
-
 f_bread:    equ  (EBIOS+00h)        ; read from onboard serial port
 f_btype:    equ  (EBIOS+03h)        ; write to onboard serial port
 f_btest:    equ  (EBIOS+06h)        ; test onboard serial port
@@ -95,5 +104,3 @@ f_dttoas:   equ  (EBIOS+27h)        ; date to ASCII string
 f_rtctest:  equ  (EBIOS+2dh)        ; test size and presence of RTC/NVR
 f_astodt:   equ  (EBIOS+30h)        ; convert ASCII string to date
 f_astotm:   equ  (EBIOS+33h)        ; convert ASCII string to time
-
-

--- a/include/ops.inc
+++ b/include/ops.inc
@@ -1,0 +1,6 @@
+.op "PUSH","N","8$1 73 9$1 73"
+.op "POP","N","60 72 B$1 F0 A$1"
+.op "CALL","W","D4 H1 L1"
+.op "RTN","","D5"
+.op "MOV","NR","8$2 A$1 9$2 B$1"
+.op "MOV","NW","F8 L2 A$1 F8 H2 B$1"


### PR DESCRIPTION
Merged changes for MChip ROM and STG ROM builds.  Changes mainly consist of three things

1) Exit address and ANYROM defined for all ROM builds
2) MChip minimon will exit to ROM menu for "/" command
3) STG code uses short branches so it fits under F800
